### PR TITLE
Fix bug with os variable in templates

### DIFF
--- a/templates/overview.erb
+++ b/templates/overview.erb
@@ -71,23 +71,24 @@
       </div>
     </div>
 
-    <!-- TODO: make this only appear if os[:family] is defined -->
-    <div class="col-md-4">
-    <div class="panel panel-default">
-      <div class="panel-heading">OS Description</div>
-        <div class="panel-body">
-          <table class="table table-striped table-hover ">
-          <tbody>
-          <tr><th>OS</th><td><%= os[:family]%></td></tr>
-          <tr><th>Release</th><td><%= os[:release]%></td></tr>
-          <tr><th>Arch</th><td><%= os[:arch]%></td></tr>
-          <tr><th>Cloud</th><td><%= ENV['CLOUD_ENV']%></td></tr>
-          <tr><th>Target</th><td><%= ENV['TARGET_HOST']%></td></tr>
-          </tbody>
-          </table>
+    <% if defined?(os) && os[:family] %>
+      <div class="col-md-4">
+        <div class="panel panel-default">
+          <div class="panel-heading">OS Description</div>
+          <div class="panel-body">
+            <table class="table table-striped table-hover ">
+              <tbody>
+              <tr><th>OS</th><td><%= os[:family]%></td></tr>
+              <tr><th>Release</th><td><%= os[:release]%></td></tr>
+              <tr><th>Arch</th><td><%= os[:arch]%></td></tr>
+              <tr><th>Cloud</th><td><%= ENV['CLOUD_ENV']%></td></tr>
+              <tr><th>Target</th><td><%= ENV['TARGET_HOST']%></td></tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
 
     <script>
     function toggleRuleDisplay(cb) {

--- a/templates/report.erb
+++ b/templates/report.erb
@@ -102,23 +102,24 @@ button.toggle_error {
         </div>
       </div>
 
-      <!-- TODO: make this only appear if os[:family] is defined -->
-      <div class="col-md-4">
-      <div class="panel panel-default">
-        <div class="panel-heading">OS Description</div>
-          <div class="panel-body">
-            <table class="table table-striped table-hover ">
-            <tbody>
-            <tr><th>OS</th><td><%= os[:family]%></td></tr>
-            <tr><th>Release</th><td><%= os[:release]%></td></tr>
-            <tr><th>Arch</th><td><%= os[:arch]%></td></tr>
-            <tr><th>Cloud</th><td><%= ENV['CLOUD_ENV']%></td></tr>
-            <tr><th>Target</th><td><%= ENV['TARGET_HOST']%></td></tr>
-            </tbody>
-            </table>
+      <% if defined?(os) && os[:family] %>
+        <div class="col-md-4">
+        <div class="panel panel-default">
+          <div class="panel-heading">OS Description</div>
+            <div class="panel-body">
+              <table class="table table-striped table-hover ">
+              <tbody>
+              <tr><th>OS</th><td><%= os[:family]%></td></tr>
+              <tr><th>Release</th><td><%= os[:release]%></td></tr>
+              <tr><th>Arch</th><td><%= os[:arch]%></td></tr>
+              <tr><th>Cloud</th><td><%= ENV['CLOUD_ENV']%></td></tr>
+              <tr><th>Target</th><td><%= ENV['TARGET_HOST']%></td></tr>
+              </tbody>
+              </table>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
 
 
       <div class="col-md-4">
@@ -212,7 +213,7 @@ button.toggle_error {
                   <% if example.has_exception? %>
                       <div class="panel panel-danger">
                         <div class="panel-heading">
-                        <button class='toggle_error' onclick="toggleErrorDisplay(this)">+</button>  
+                        <button class='toggle_error' onclick="toggleErrorDisplay(this)">+</button>
                           <h3 class="panel-title"><%= example.exception.klass %></h3>
                         </div>
                         <div class="panel-body">


### PR DESCRIPTION
I was getting an error about the `os` variable not being defined when templates were generated. Popping open my debugger, I found the following TODO in the templates:

```html
<!-- TODO: make this only appear if os[:family] is defined -->
```

Added a check in the templates, and now all's well.